### PR TITLE
Enable ctrl-backspace in the IFF field

### DIFF
--- a/EIC Tracker/EIC Tracker/Form1.Designer.cs
+++ b/EIC Tracker/EIC Tracker/Form1.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace EIC_Tracker
+﻿using System.Windows.Forms;
+
+namespace EIC_Tracker
 {
     partial class frmMain
     {
@@ -851,6 +853,8 @@
             // 
             resources.ApplyResources(this.txtIFF, "txtIFF");
             this.txtIFF.Name = "txtIFF";
+            this.txtIFF.AutoCompleteMode = AutoCompleteMode.Append;
+            this.txtIFF.AutoCompleteSource = AutoCompleteSource.RecentlyUsedList;
             this.txtIFF.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtIFF_KeyDown);
             // 
             // label5

--- a/EIC Tracker/EIC Tracker/Form1.Designer.cs
+++ b/EIC Tracker/EIC Tracker/Form1.Designer.cs
@@ -123,6 +123,7 @@ namespace EIC_Tracker
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.btnCommodity = new System.Windows.Forms.Button();
             this.txtIFF = new System.Windows.Forms.TextBox();
+            this.txtIFFHistory = new AutoCompleteStringCollection();
             this.label5 = new System.Windows.Forms.Label();
             this.btnIFF = new System.Windows.Forms.Button();
             this.lblDonate = new System.Windows.Forms.Label();
@@ -853,9 +854,13 @@ namespace EIC_Tracker
             // 
             resources.ApplyResources(this.txtIFF, "txtIFF");
             this.txtIFF.Name = "txtIFF";
-            this.txtIFF.AutoCompleteMode = AutoCompleteMode.Append;
-            this.txtIFF.AutoCompleteSource = AutoCompleteSource.RecentlyUsedList;
             this.txtIFF.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtIFF_KeyDown);
+            // 
+            // Setup txtIFF's autocomplete features
+            //
+            this.txtIFF.AutoCompleteMode = AutoCompleteMode.Append;
+            this.txtIFF.AutoCompleteSource = AutoCompleteSource.CustomSource;
+            this.txtIFF.AutoCompleteCustomSource = this.txtIFFHistory;
             // 
             // label5
             // 
@@ -1183,6 +1188,10 @@ namespace EIC_Tracker
         private System.Data.DataColumn dataColumn26;
         private System.Data.DataColumn dataColumn27;
         private System.Windows.Forms.TextBox txtIFF;
+        /// <summary>
+        /// History of IFF lookups
+        /// </summary>
+        private AutoCompleteStringCollection txtIFFHistory;
         private System.Windows.Forms.Label label5;
         public System.Windows.Forms.Button btnIFF;
         private System.Windows.Forms.Label lblDonate;

--- a/EIC Tracker/EIC Tracker/Form1.cs
+++ b/EIC Tracker/EIC Tracker/Form1.cs
@@ -2822,6 +2822,8 @@ namespace EIC_Tracker
         {
             if (txtIFF.Text != "")
             {
+                // add the commander to the history for auto-completion
+                this.txtIFFHistory.Add(this.txtIFF.Text);
                 //Add a completed handler so that we know when to submit the form.
                 var url = "http://tracker.eicgaming.com/commander.php?CMDR=" + Globals.cmdr + "&x=" + Globals.cursystemx + "&y=" + Globals.cursystemy + "&z=" + Globals.cursystemz + "&System=" + Globals.cursystem + "&Version=" + Globals.version;
                 DisplayHtml("<form action='" + url + "' method='post' id='IFFForm'><textarea name='IFF' style='display:none'>" + txtIFF.Text + "</textarea><input type='hidden' name='journal' value='" + Globals.journalFile + "'><input type='hidden' name='version' value='" + Globals.version + "'><input type='submit'></form>", "1");


### PR DESCRIPTION
This PR enables auto-complete functionality for the IFF textbox in JTracker. 
The primary motivation here is to enable ctrl-backspace functionality (this shortcut keypress deletes the last word, and is equal to shift-leftarrow delete. )

As a secondary effect, as to prevent strange auto-complete behavior i have implemented it as to remember previous IFF lookups, and suggest them as the user starts typing. This makes it easier to use, especially when looking up a commander with a very non-standard nickname for the second or third times.

This PR is minimally invasive, and doesn't appear to break anything. I have not touched anything in the codebase that i did not need to.